### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
   ],
   "author": "Andrew Clark <acdlite@me.com>",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/acdlite/json-sass.git"
+  },
   "dependencies": {
     "babel": "~4.1.0",
     "lodash": "~2.4.1",


### PR DESCRIPTION
When installing this package via npm, I get the following warning:

> npm WARN package.json json-sass@1.3.5 No repository field.

Documentation: https://docs.npmjs.com/files/package.json#repository

Adding this field to the package.json file should make this warning
disappear.

Fixes #3.
