### PR TITLE
update export and change to map iteration

### DIFF
--- a/src/jsToSassString.js
+++ b/src/jsToSassString.js
@@ -39,10 +39,10 @@ function jsToSassString(value) {
           return result;
         }
         else if (isArray(value)) {
-          let sassVals = [
-            for (v of value) if (isNotUndefined(v))
-              _jsToSassString(v, indentLevel)
-          ];
+          let sassVals = value.map((v) => isNotUndefined(v) ?
+					  _jsToSassString(v, indentLevel) :
+					  null)
+			      .filter((v) => v !== null);
 
           return '(' + sassVals.join(', ') + ')';
         }

--- a/src/jsonSass.js
+++ b/src/jsonSass.js
@@ -21,6 +21,5 @@ function jsonSass(options) {
   });
 }
 
-module.exports = jsonSass;
+jsonSass.convertJs = jsToSassString;
 export default jsonSass;
-export { jsToSassString as convertJs };


### PR DESCRIPTION
- Fix #5 (and #6)
- Support older versions of node that don't have Symbol available.

I believe this way of handling the exports is better because it keeps it all within babel and doesn't leak the underlying module system into the code.
As for not using array comprehensions, I think that it's not quite necessary and makes the versions of node that this works on wider as it doesn't require the Symbol polyfill. In addition, it's probably easier to understand a `Array#map` than an array comprehension.
