### PR TITLE
Catch JSON.parse error

### DIFF
--- a/src/jsonSass.js
+++ b/src/jsonSass.js
@@ -13,7 +13,13 @@ function jsonSass(options) {
   let options = assign({}, DEFAULTS, options);
 
   return through(function(chunk, enc, callback) {
-    let jsValue = JSON.parse(chunk);
+    let jsValue;
+    try {
+      jsValue = JSON.parse(chunk);
+    }
+    catch (err) {
+      return callback(err);
+    }
     let sassString = jsToSassString(jsValue);
     sassString = options.prefix + sassString + options.suffix;
     this.push(sassString);


### PR DESCRIPTION
Catch JSON.parse error so that unhandled errors aren't thrown.  With this addition, you can handle the errors in your stream like this (making sure the on error handler is directly after the pipe to jsonSass).

```
  fs.createReadStream(configPath)
    .pipe(jsonSass({
      prefix: '$config: '
    }))
    .on('error', function(e){
      console.log('ERROR: ' + e);
      done(e);
    });
```
